### PR TITLE
Fix/front camera mirroring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'org.jetbrains.dokka'
 buildscript {
     ext {
         // Upgrade StreamPack version here
-        streampackCode = 2_005_002
-        streampackVersion = '2.5.2'
+        streampackCode = 2_005_003
+        streampackVersion = '2.5.3'
 
         minSdk = 21
         compileSdk = 31

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'org.jetbrains.dokka'
 buildscript {
     ext {
         // Upgrade StreamPack version here
-        streampackCode = 2_005_004
-        streampackVersion = '2.5.4'
+        streampackCode = 2_005_005
+        streampackVersion = '2.5.5'
 
         minSdk = 21
         compileSdk = 31

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext {
         // Upgrade StreamPack version here
         streampackCode = 2_005_004
-        streampackVersion = '2.5.4ª'
+        streampackVersion = '2.5.4'
 
         minSdk = 21
         compileSdk = 31

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'org.jetbrains.dokka'
 buildscript {
     ext {
         // Upgrade StreamPack version here
-        streampackCode = 2_005_003
-        streampackVersion = '2.5.3'
+        streampackCode = 2_005_004
+        streampackVersion = '2.5.4ª'
 
         minSdk = 21
         compileSdk = 31

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'org.jetbrains.dokka'
 buildscript {
     ext {
         // Upgrade StreamPack version here
-        streampackCode = 2_005_005
-        streampackVersion = '2.5.5'
+        streampackCode = 2_005_007
+        streampackVersion = '2.5.7'
 
         minSdk = 21
         compileSdk = 31

--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/encoders/MediaCodecEncoder.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/encoders/MediaCodecEncoder.kt
@@ -83,14 +83,6 @@ abstract class MediaCodecEncoder<T : Config>(
 
                             // Remove startCode + sps + startCode + pps
                             var frameBuffer = buffer
-                            if (isFrontCamera) {
-                                val flippedBuffer = ByteBuffer.allocate(frameBuffer.remaining())
-                                for (i in frameBuffer.remaining() - 1 downTo 0) {
-                                    flippedBuffer.put(frameBuffer[i])
-                                }
-                                flippedBuffer.flip()
-                                frameBuffer = flippedBuffer
-                            }   
                             extra?.let { it ->
                                 var prefix = ByteArray(0)
                                 it.forEach { csd -> prefix = prefix.plus(csd.extractArray()) }

--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/encoders/MediaCodecEncoder.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/encoders/MediaCodecEncoder.kt
@@ -83,6 +83,14 @@ abstract class MediaCodecEncoder<T : Config>(
 
                             // Remove startCode + sps + startCode + pps
                             var frameBuffer = buffer
+                            if (isFrontCamera) {
+                                val flippedBuffer = ByteBuffer.allocate(frameBuffer.remaining())
+                                for (i in frameBuffer.remaining() - 1 downTo 0) {
+                                    flippedBuffer.put(frameBuffer[i])
+                                }
+                                flippedBuffer.flip()
+                                frameBuffer = flippedBuffer
+                            }   
                             extra?.let { it ->
                                 var prefix = ByteArray(0)
                                 it.forEach { csd -> prefix = prefix.plus(csd.extractArray()) }

--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/encoders/VideoMediaCodecEncoder.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/encoders/VideoMediaCodecEncoder.kt
@@ -112,6 +112,7 @@ class VideoMediaCodecEncoder(
         private val orientationProvider: IOrientationProvider
     ) :
         SurfaceTexture.OnFrameAvailableListener, OnCameraListener {
+        private var isFrontCamera = false
         private var eglSurface: EGlSurface? = null
         private var fullFrameRect: FullFrameRect? = null
         private var textureId = -1
@@ -152,7 +153,8 @@ class VideoMediaCodecEncoder(
                     textureId = createTextureObject()
                     setMVPMatrixAndViewPort(
                         orientationProvider.orientation.toFloat(),
-                        Size(width, height)
+                        Size(width, height),
+                        isFrontCamera,
                     )
                 }
 
@@ -242,6 +244,7 @@ class VideoMediaCodecEncoder(
         }
 
         override fun onCameraOpened(cameraId: String, isFrontCamera: Boolean) {
+            this.isFrontCamera = isFrontCamera
             fullFrameRect?.setIsMirrored(isFrontCamera)
         }
     }

--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/encoders/VideoMediaCodecEncoder.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/encoders/VideoMediaCodecEncoder.kt
@@ -29,6 +29,8 @@ import io.github.thibaultbee.streampack.internal.gl.EGlSurface
 import io.github.thibaultbee.streampack.internal.gl.FullFrameRect
 import io.github.thibaultbee.streampack.internal.gl.Texture2DProgram
 import io.github.thibaultbee.streampack.internal.interfaces.IOrientationProvider
+import io.github.thibaultbee.streampack.listeners.CameraEventBridge
+import io.github.thibaultbee.streampack.listeners.OnCameraListener
 import io.github.thibaultbee.streampack.listeners.OnErrorListener
 import java.util.concurrent.Executors
 
@@ -109,7 +111,7 @@ class VideoMediaCodecEncoder(
     class CodecSurface(
         private val orientationProvider: IOrientationProvider
     ) :
-        SurfaceTexture.OnFrameAvailableListener {
+        SurfaceTexture.OnFrameAvailableListener, OnCameraListener {
         private var eglSurface: EGlSurface? = null
         private var fullFrameRect: FullFrameRect? = null
         private var textureId = -1
@@ -121,6 +123,8 @@ class VideoMediaCodecEncoder(
 
         var surface: Surface? = null
             set(value) {
+
+                CameraEventBridge.listener = this
 
                 /**
                  * When surface is called twice without the stopStream(). When configure() is
@@ -235,6 +239,10 @@ class VideoMediaCodecEncoder(
             stopStream()
             surfaceTexture?.release()
             surfaceTexture = null
+        }
+
+        override fun onCameraOpened(cameraId: String, isFrontCamera: Boolean) {
+            fullFrameRect?.setIsMirrored(isFrontCamera)
         }
     }
 }

--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/encoders/VideoMediaCodecEncoder.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/encoders/VideoMediaCodecEncoder.kt
@@ -245,6 +245,7 @@ class VideoMediaCodecEncoder(
 
         override fun onCameraOpened(cameraId: String, isFrontCamera: Boolean) {
             this.isFrontCamera = isFrontCamera
+            println("LB: isFrontCamera camera opened $isFrontCamera")
             fullFrameRect?.setIsMirrored(isFrontCamera)
         }
     }

--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/gl/FullFrameRect.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/gl/FullFrameRect.kt
@@ -32,6 +32,7 @@ import java.nio.FloatBuffer
  */
 class FullFrameRect(var program: Texture2DProgram) {
     private val mvpMatrix = FloatArray(16)
+    private var isMirrored = false
 
     companion object {
         /**
@@ -103,21 +104,21 @@ class FullFrameRect(var program: Texture2DProgram) {
         return program.createTextureObject()
     }
 
-    fun setMVPMatrixAndViewPort(rotation: Float, resolution: Size) {
+    fun setMVPMatrixAndViewPort(rotation: Float, resolution: Size, isFrontCamera: Boolean) {
         Matrix.setIdentityM(mvpMatrix, 0)
         Matrix.rotateM(
             mvpMatrix, 0,
             rotation, 0f, 0f, -1f
         )
         GLES20.glViewport(0, 0, resolution.width, resolution.height)
-        // since the matrix was reset above, we need re-apply the mirror transformation
+
+        // reset mirroring (don't call setIsMirrored here)
+        isMirrored = isFrontCamera
         if (isMirrored) {
-            // if video was mirrored before, flip the matrix
             Matrix.scaleM(mvpMatrix, 0, -1f, 1f, 1f)
         }
     }
 
-    private var isMirrored = false
     fun setIsMirrored(targetState: Boolean) {
         if (isMirrored != targetState) {
             // if they are different, run scaleM once to flip the -1 on the x axis

--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/gl/FullFrameRect.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/gl/FullFrameRect.kt
@@ -112,6 +112,16 @@ class FullFrameRect(var program: Texture2DProgram) {
         GLES20.glViewport(0, 0, resolution.width, resolution.height)
     }
 
+    private var isMirrored = false
+    fun setIsMirrored(targetState: Boolean) {
+        if (isMirrored != targetState) {
+            // if they are different, run scaleM once to flip the -1 on the x axis
+            Matrix.scaleM(mvpMatrix, 0, -1f, 1f, 1f)
+        }
+        isMirrored = targetState
+    }
+
+
     /**
      * Draws a viewport-filling rect, texturing it with the specified texture object.
      */

--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/gl/FullFrameRect.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/gl/FullFrameRect.kt
@@ -111,16 +111,20 @@ class FullFrameRect(var program: Texture2DProgram) {
             rotation, 0f, 0f, -1f
         )
         GLES20.glViewport(0, 0, resolution.width, resolution.height)
+        println("LB: isFrontCamera $isFrontCamera")
 
         // reset mirroring (don't call setIsMirrored here)
         isMirrored = isFrontCamera
+        println("LB: isMirrored in matrix $isMirrored")
         if (isMirrored) {
             Matrix.scaleM(mvpMatrix, 0, -1f, 1f, 1f)
         }
     }
 
     fun setIsMirrored(targetState: Boolean) {
+        println("LB: setting is mirrored")
         if (isMirrored != targetState) {
+            println("LB: isMirrored $isMirrored")
             // if they are different, run scaleM once to flip the -1 on the x axis
             Matrix.scaleM(mvpMatrix, 0, -1f, 1f, 1f)
         }

--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/gl/FullFrameRect.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/gl/FullFrameRect.kt
@@ -110,6 +110,11 @@ class FullFrameRect(var program: Texture2DProgram) {
             rotation, 0f, 0f, -1f
         )
         GLES20.glViewport(0, 0, resolution.width, resolution.height)
+        // since the matrix was reset above, we need re-apply the mirror transformation
+        if (isMirrored) {
+            // if video was mirrored before, flip the matrix
+            Matrix.scaleM(mvpMatrix, 0, -1f, 1f, 1f)
+        }
     }
 
     private var isMirrored = false

--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/sources/camera/CameraController.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/sources/camera/CameraController.kt
@@ -25,8 +25,10 @@ import android.util.Range
 import android.view.Surface
 import androidx.annotation.RequiresPermission
 import io.github.thibaultbee.streampack.error.CameraError
+import io.github.thibaultbee.streampack.listeners.CameraEventBridge
 import io.github.thibaultbee.streampack.logger.Logger
 import io.github.thibaultbee.streampack.utils.TAG
+import io.github.thibaultbee.streampack.utils.isFrontCamera
 import kotlinx.coroutines.*
 import java.security.InvalidParameterException
 import kotlin.coroutines.resume
@@ -75,8 +77,13 @@ class CameraController(
 
     private class CameraDeviceCallback(
         private val cont: CancellableContinuation<CameraDevice>,
+        private val context: Context,
     ) : CameraDevice.StateCallback() {
-        override fun onOpened(device: CameraDevice) = cont.resume(device)
+
+        override fun onOpened(device: CameraDevice) {
+            cont.resume(device)
+            CameraEventBridge.cameraOpened(device.id, context.isFrontCamera(device.id))
+        }
 
         override fun onDisconnected(camera: CameraDevice) {
             Logger.w(TAG, "Camera ${camera.id} has been disconnected")
@@ -127,7 +134,7 @@ class CameraController(
         threadManager.openCamera(
             manager,
             cameraId,
-            CameraDeviceCallback(cont)
+            CameraDeviceCallback(cont, context)
         )
     }
 

--- a/core/src/main/java/io/github/thibaultbee/streampack/listeners/OnCameraListener.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/listeners/OnCameraListener.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2021 Thibault B.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.thibaultbee.streampack.listeners
+
+/**
+ * Simple event bridge for when the camera changes.
+ */
+object CameraEventBridge {
+    var listener: OnCameraListener? = null
+
+    fun cameraOpened(cameraId: String, isFrontCamera: Boolean) {
+        listener?.onCameraOpened(cameraId, isFrontCamera)
+    }
+}
+
+/**
+ * Interface for functions that implement onCameraOpened.
+ */
+interface OnCameraListener {
+
+    fun onCameraOpened(cameraId: String, isFrontCamera: Boolean)
+}


### PR DESCRIPTION
## Issue(s) or Summary

https://livebuy.atlassian.net/browse/CAP-512 

## Changes

This PR implements flipping the outputted video stream (that goes to MUX). In the process of figuring a way to do this, I discovered that the frame buffer inside of the `MediaCodecEncoder` [file](https://github.com/livebuy/StreamPack/blob/3a9af52fd6f34c2dac308ece85a2a38c6d64760e/core/src/main/java/io/github/thibaultbee/streampack/internal/encoders/MediaCodecEncoder.kt#L4) uses YUV encoding, making flipping it difficult because of all the byte magic, and there will be no guarantees on the format. 

Instead this PR takes advantage of the fact that the library uses camera to texture whereby the camera output gets routed through a shader. This shader can be leveraged by scaling the transformation matrix to flip the video. 

In order to know when the camera view changes, I added a simple bridge listener.

- transform `mvpMatrix` to flip -1 on x-axis if camera is on front camera 
- add bridge between `CameraController` and `VideoMediaCodecEncoder` to listen for if the camera view changes  

<img width="724" alt="Screenshot 2023-07-17 at 11 46 54" src="https://github.com/ThibaultBee/StreamPack/assets/112614103/b332e074-2244-402b-8699-53d6426e6f86">


### Notes: 
The changes in this PR can currently only be tested using StreamPack library, since I am experencing some complications when updating the dependencies in our forked [android-live-stream](https://github.com/livebuy/api.video-android-live-stream/blob/main/livestream/build.gradle) library.
Because android-live-stream also points to `"io.github.thibaultbee:streampack-extension-rtmp:$streamPackVersion"` in the build.gradle [file](https://github.com/livebuy/api.video-android-live-stream/blob/main/livestream/build.gradle), it seems to produce `duplicate class` errors when changing 
- ` api "io.github.thibaultbee:streampack:$streamPackVersion"` 
to  
- `api "com.github.livebuy:streampack"` 

Looking into best potential solutions for this.. One potential solution could be to copy the aar files from StreamPack directly into our forked video-android-live-stream library, but not sure if this would be the best option.. 

![Screenshot 2023-07-17 at 16 43 16](https://github.com/livebuy/StreamPack/assets/112614103/1bbe2177-d22f-46e4-be73-2d3622d85c48)

